### PR TITLE
Make sure dataset version is all lowercase

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -9,7 +9,7 @@ def get_run_identification():
     try:
         with open("/valohai/config/execution.json") as f:
             exec_details = json.load(f)
-        project_name = exec_details["valohai.project-name"].split("/")[1]
+        project_name = exec_details["valohai.project-name"].split("/")[1].lower()
         exec_id = exec_details["valohai.execution-id"]
     except FileNotFoundError:
         project_name = "test"


### PR DESCRIPTION
Make sure we lower the project name because:

> Dataset Version name must be lowercase, start with a letter or number and may contain letters, numbers, dashes, dots, and underscores thereafter.